### PR TITLE
Update examples when using dvswitch

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -213,9 +213,9 @@ EXAMPLES = '''
 
 -  name: Add Management vmkernel port to Distributed Switch
    vmware_vmkernel:
-      hostname: '{{ esxi_hostname }}'
-      username: '{{ esxi_username }}'
-      password: '{{ esxi_password }}'
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
       esxi_hostname: '{{ esxi_hostname }}'
       dvswitch_name: dvSwitch1
       portgroup_name: dvPG_0001
@@ -229,9 +229,9 @@ EXAMPLES = '''
 
 -  name: Add vMotion vmkernel port with vMotion TCP/IP stack
    vmware_vmkernel:
-      hostname: '{{ esxi_hostname }}'
-      username: '{{ esxi_username }}'
-      password: '{{ esxi_password }}'
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
       esxi_hostname: '{{ esxi_hostname }}'
       dvswitch_name: dvSwitch1
       portgroup_name: dvPG_0001


### PR DESCRIPTION
 Update examples when using dvswitch to use vcenter connection details rather than esxi connection details.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the documentation examples to clarify that vcenter connection details should be used when using a dvswitch.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vmkernel.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
